### PR TITLE
Unified LogMsgType constants and refactored data types

### DIFF
--- a/logmsg.go
+++ b/logmsg.go
@@ -9,13 +9,6 @@ import (
 	"time"
 )
 
-const (
-	// RFC3164 represents the legacy BSD-syslog message type.
-	RFC3164 LogMsgType = "RFC3164"
-	// RFC5424 represents the modern IETF-syslog message type.
-	RFC5424 LogMsgType = "RFC5424"
-)
-
 // LogMsg represents a Syslog message containing metadata and parsed log content based on RFC specifications.
 type LogMsg struct {
 	App            []byte

--- a/logmsg.go
+++ b/logmsg.go
@@ -9,22 +9,28 @@ import (
 	"time"
 )
 
-// LogMsg represents a Syslog message containing metadata and parsed log content based on RFC specifications.
+// LogMsg represents a Syslog message as defined by the Parser, with fields for structured and
+// unstructured data
 type LogMsg struct {
-	App            []byte
-	Facility       Facility
-	HasBOM         bool
-	Host           []byte
+	// Wide and/or bulky types first
 	Message        bytes.Buffer
-	MsgLength      int
-	MsgID          []byte
-	Priority       Priority
-	PID            []byte
-	ProtoVersion   ProtoVersion
-	Severity       Severity
-	StructuredData []StructuredDataElement
 	Timestamp      time.Time
-	Type           LogMsgType
+	App            []byte
+	Host           []byte
+	MsgID          []byte
+	PID            []byte
+	StructuredData []StructuredDataElement
+
+	// Medium size types
+	Type LogMsgType
+
+	MsgLength    int32
+	Facility     Facility
+	Priority     Priority
+	ProtoVersion ProtoVersion
+	Severity     Severity
+	HasBOM       bool
+	_            [2]byte
 }
 
 // LogMsgType represents the type of a Syslog message, typically defined by RFC specifications such as
@@ -32,7 +38,7 @@ type LogMsg struct {
 type LogMsgType string
 
 // ProtoVersion represents the version of the Syslog protocol as defined in RFC5424.
-type ProtoVersion int
+type ProtoVersion uint8
 
 // StructuredDataElement represents a structured data element in an RFC5424 Syslog message.
 // See: https://datatracker.ietf.org/doc/html/rfc5424#section-6.3.1

--- a/priority.go
+++ b/priority.go
@@ -8,13 +8,13 @@ package parsesyslog
 const SeverityMask = 0x07
 
 // Severity represents the serverity part of the Syslog PRI header
-type Severity int
+type Severity uint8
 
 // Facility represents the facility part of the Syslog PRI header
-type Facility int
+type Facility uint8
 
 // Priority represents the Syslog PRI header
-type Priority int
+type Priority uint8
 
 // Severities
 const (

--- a/rfc3164/rfc3164.go
+++ b/rfc3164/rfc3164.go
@@ -98,7 +98,7 @@ func (r *rfc3164) ParseReader(reader io.Reader) (parsesyslog.LogMsg, error) {
 			return logMessage, fmt.Errorf("failed to write bytes: %w", err)
 		}
 	}
-	logMessage.MsgLength = logMessage.Message.Len()
+	logMessage.MsgLength = int32(logMessage.Message.Len())
 
 	return logMessage, nil
 }

--- a/rfc3164/rfc3164.go
+++ b/rfc3164/rfc3164.go
@@ -28,6 +28,8 @@ type rfc3164 struct {
 const (
 	// Type represents the ParserType for this Parser
 	Type parsesyslog.ParserType = "rfc3164"
+	// MsgType represents the log message type of this package
+	MsgType parsesyslog.LogMsgType = "RFC3164"
 )
 
 const (
@@ -68,7 +70,7 @@ func (r *rfc3164) ParseString(message string) (parsesyslog.LogMsg, error) {
 // ParseReader parses syslog messages from an io.Reader according to RFC3164 and returns a LogMsg or an error.
 func (r *rfc3164) ParseReader(reader io.Reader) (parsesyslog.LogMsg, error) {
 	logMessage := parsesyslog.LogMsg{
-		Type: parsesyslog.RFC3164,
+		Type: MsgType,
 	}
 	r.reol = false
 

--- a/rfc5424/rfc5424.go
+++ b/rfc5424/rfc5424.go
@@ -99,7 +99,7 @@ func (r *rfc5424) ParseReader(reader io.Reader) (parsesyslog.LogMsg, error) {
 		return logMessage, fmt.Errorf("failed to read log message content: %w", err)
 	}
 	logMessage.Message.Write(md)
-	logMessage.MsgLength = logMessage.Message.Len()
+	logMessage.MsgLength = int32(logMessage.Message.Len())
 
 	if msgReader.Buffered() != 0 {
 		return logMessage, parsesyslog.ErrInvalidLength

--- a/rfc5424/rfc5424.go
+++ b/rfc5424/rfc5424.go
@@ -34,8 +34,12 @@ type rfc5424 struct {
 	sds    []parsesyslog.StructuredDataElement
 }
 
-// Type represents the ParserType for this Parser
-const Type parsesyslog.ParserType = "rfc5424"
+const (
+	// Type represents the ParserType for this parser
+	Type parsesyslog.ParserType = "rfc5424"
+	// MsgType represents the log message type of this parser
+	MsgType parsesyslog.LogMsgType = "RFC3164"
+)
 
 // init registers the Parser
 func init() {
@@ -61,7 +65,7 @@ func (r *rfc5424) ParseString(s string) (parsesyslog.LogMsg, error) {
 func (r *rfc5424) ParseReader(reader io.Reader) (parsesyslog.LogMsg, error) {
 	r.offset, r.len = 0, 0
 	logMessage := parsesyslog.LogMsg{
-		Type: parsesyslog.RFC5424,
+		Type: MsgType,
 	}
 
 	msgReader, ok := reader.(*bufio.Reader)

--- a/rfc5424/rfc5424_test.go
+++ b/rfc5424/rfc5424_test.go
@@ -146,7 +146,7 @@ func TestRfc5424_ParseReader(t *testing.T) {
 		if !strings.EqualFold(logMessage.Message.String(), expectMsg) {
 			t.Errorf("expected message to be: %q, got: %q", expectMsg, logMessage.Message.String())
 		}
-		if logMessage.MsgLength != len(expectMsg) {
+		if logMessage.MsgLength != int32(len(expectMsg)) {
 			t.Errorf("expected message length to be: %d, got: %d", len(expectMsg), logMessage.MsgLength)
 		}
 


### PR DESCRIPTION
- Moved `LogMsgType` constants (`RFC3164`, `RFC5424`) from `logmsg.go` into parser-specific files for better encapsulation
- Updated `ParseReader` methods in both parsers to use newly defined parser-local `MsgType` constants
- Enhanced code maintainability by removing redundant global constants in `logmsg.go`
- Updated `Severity`, `Facility`, `Priority`, and `ProtoVersion` types to `uint8` for consistency and memory optimization
- Changed `MsgLength` type from `int` to `int32` for better alignment with protocol specifications
- Reorganized `LogMsg` struct fields for optimal memory layout
- Adjusted related parser methods and tests to reflect type changes